### PR TITLE
#18-very-basic-donate-function

### DIFF
--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -2,12 +2,19 @@ package com.example.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
 public class BackendApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BackendApplication.class, args);
+    }
+
+    @Bean
+    public WebClient getWebClient(){
+        return WebClient.create();
     }
 
 }

--- a/backend/src/main/java/com/example/backend/api/CountriesApiService.java
+++ b/backend/src/main/java/com/example/backend/api/CountriesApiService.java
@@ -1,0 +1,34 @@
+package com.example.backend.api;
+
+import com.example.backend.model.Country;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Service
+public class CountriesApiService {
+
+    private final WebClient webClient;
+
+    public CountriesApiService(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public List<Country> retrieveCountries() {
+
+        //API CALL
+         List<Country> countries = webClient.get()
+                .uri("https://restcountries.com/v2/all?fields=name,region")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .toEntityList(Country.class)
+                .block()
+                .getBody();
+
+        return countries;
+    }
+}
+

--- a/backend/src/main/java/com/example/backend/controller/NgoController.java
+++ b/backend/src/main/java/com/example/backend/controller/NgoController.java
@@ -1,6 +1,7 @@
 package com.example.backend.controller;
 
 import com.example.backend.dto.NgoDto;
+import com.example.backend.model.Country;
 import com.example.backend.model.Ngo;
 import com.example.backend.service.NgoService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,5 +45,11 @@ public class NgoController {
     public void deleteNgoById(@PathVariable String id) {
         ngoService.deleteNgoById(id);
     }
+
+    @GetMapping("/countries")
+    public List<Country> getAllCountries() {
+        return ngoService.getAllCountries();
+    }
+
 }
 

--- a/backend/src/main/java/com/example/backend/model/Country.java
+++ b/backend/src/main/java/com/example/backend/model/Country.java
@@ -1,0 +1,22 @@
+package com.example.backend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Country {
+
+    @Id
+    private String id;
+    private String name;
+    private String region;
+
+}
+
+

--- a/backend/src/main/java/com/example/backend/service/NgoService.java
+++ b/backend/src/main/java/com/example/backend/service/NgoService.java
@@ -1,6 +1,8 @@
 package com.example.backend.service;
 
+import com.example.backend.api.CountriesApiService;
 import com.example.backend.dto.NgoDto;
+import com.example.backend.model.Country;
 import com.example.backend.model.Ngo;
 import com.example.backend.repository.NgoRepo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +15,12 @@ import java.util.NoSuchElementException;
 public class NgoService {
 
     private final NgoRepo ngoRepo;
+    private final CountriesApiService countriesApiService;
 
     @Autowired
-    public NgoService(NgoRepo ngoRepo) {
+    public NgoService(NgoRepo ngoRepo, CountriesApiService countriesApiService) {
         this.ngoRepo = ngoRepo;
+        this.countriesApiService = countriesApiService;
     }
 
     public List<Ngo> getNgos() {
@@ -34,6 +38,7 @@ public class NgoService {
         newNgo.setImage(ngoDto.getImage());
         newNgo.setCity(ngoDto.getCity());
         newNgo.setCountry(ngoDto.getCountry());
+        //TODO
         newNgo.setRegion(ngoDto.getRegion());
         return ngoRepo.insert(newNgo);
     }
@@ -49,6 +54,10 @@ public class NgoService {
 
     public void deleteNgoById(String id) {
         ngoRepo.deleteById(id);
+    }
+
+    public List<Country> getAllCountries() {
+        return countriesApiService.retrieveCountries();
     }
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.data.mongodb.database=CharistDB
 spring.data.mongodb.uri=${MONGO_DB_URI}
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/raleway": "^4.5.8",
         "@fontsource/roboto": "^4.5.7",
+        "@paypal/react-paypal-js": "^7.8.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2916,6 +2917,35 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paypal/paypal-js": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.6.tgz",
+      "integrity": "sha512-q40h/Rc2Dus5p7Ctgq8EQyyqWGVCdfaezi4D5eWSIl2+p0FHL1mBA4XnXYgv9FPYejrVUmnIATdbqBdEYwasYg==",
+      "dependencies": {
+        "promise-polyfill": "^8.2.3"
+      }
+    },
+    "node_modules/@paypal/react-paypal-js": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-7.8.1.tgz",
+      "integrity": "sha512-+cAa0QLJUO1TUlFk/xqJsfEm6Ywtg3kvMmxf2EJcmVJDkNHc6+7Qq2o6Gt1mTn16ZG4/2uWRROeKcoXFFdNrQA==",
+      "dependencies": {
+        "@paypal/paypal-js": "^5.0.6",
+        "@paypal/sdk-constants": "^1.0.116"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/@paypal/sdk-constants": {
+      "version": "1.0.122",
+      "resolved": "https://registry.npmjs.org/@paypal/sdk-constants/-/sdk-constants-1.0.122.tgz",
+      "integrity": "sha512-bxML2CX9acBGuigb5aCz1E8wcxtRpuXuY2hvfQKAG9fB0zG9d8nEcRiSYavbx4n2UM5TqwEcFo/roPD3aqykOg==",
+      "dependencies": {
+        "hi-base32": "^0.5.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -8300,6 +8330,11 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
     "node_modules/history": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
@@ -13379,6 +13414,11 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -18628,6 +18668,31 @@
         "fastq": "^1.6.0"
       }
     },
+    "@paypal/paypal-js": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.6.tgz",
+      "integrity": "sha512-q40h/Rc2Dus5p7Ctgq8EQyyqWGVCdfaezi4D5eWSIl2+p0FHL1mBA4XnXYgv9FPYejrVUmnIATdbqBdEYwasYg==",
+      "requires": {
+        "promise-polyfill": "^8.2.3"
+      }
+    },
+    "@paypal/react-paypal-js": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-7.8.1.tgz",
+      "integrity": "sha512-+cAa0QLJUO1TUlFk/xqJsfEm6Ywtg3kvMmxf2EJcmVJDkNHc6+7Qq2o6Gt1mTn16ZG4/2uWRROeKcoXFFdNrQA==",
+      "requires": {
+        "@paypal/paypal-js": "^5.0.6",
+        "@paypal/sdk-constants": "^1.0.116"
+      }
+    },
+    "@paypal/sdk-constants": {
+      "version": "1.0.122",
+      "resolved": "https://registry.npmjs.org/@paypal/sdk-constants/-/sdk-constants-1.0.122.tgz",
+      "integrity": "sha512-bxML2CX9acBGuigb5aCz1E8wcxtRpuXuY2hvfQKAG9fB0zG9d8nEcRiSYavbx4n2UM5TqwEcFo/roPD3aqykOg==",
+      "requires": {
+        "hi-base32": "^0.5.0"
+      }
+    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz",
@@ -22556,6 +22621,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
     "history": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
@@ -26085,6 +26155,11 @@
       "requires": {
         "asap": "~2.0.6"
       }
+    },
+    "promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
     },
     "prompts": {
       "version": "2.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fontsource/raleway": "^4.5.8",
     "@fontsource/roboto": "^4.5.7",
+    "@paypal/react-paypal-js": "^7.8.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,9 @@
       name="description"
       content="Made by Katharina-Sophie Winkler"
     />
+    <meta name="viewport" content="width=device-width, initial-scale=1"> <!-- Ensures optimal rendering on mobile devices. -->
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> <!-- Optimal Internet Explorer compatibility -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -33,6 +36,7 @@
     <title>charist</title>
   </head>
   <body>
+  <script src="https://www.paypalobjects.com/donate/sdk/donate-sdk.js" charset="UTF-8"></script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,12 +9,17 @@ import useNgos from "./hooks/useNgos";
 import ForNgos from "./pages/ForNgos";
 import NgoDetailsPage from "./pages/NgoDetailsPage";
 import AppNav from "./components/AppNav";
+import {PayPalScriptProvider} from "@paypal/react-paypal-js";
+
 
 export default function App() {
 
     const {ngos, addNgo, updateNgo, deleteNgo} = useNgos();
 
   return (
+      <div>
+          (//TODO)
+          <PayPalScriptProvider options={{"client-id": "AQ_r8Wlh7sYBG7vbL59BzKxUyTtMXhJI-gS0u0iYgirds2gR7H0dj7GFNb6Os0U8d6fpnwFU1_aPjCnV"}}>
       <BrowserRouter>
           <AppNav/>
           <Routes>
@@ -31,6 +36,8 @@ export default function App() {
                          deleteNgoById={deleteNgo}/>}/>
           </Routes>
       </BrowserRouter>
+          </PayPalScriptProvider>
+      </div>
   )
 }
 

--- a/frontend/src/components/FilterNgosBySdg.tsx
+++ b/frontend/src/components/FilterNgosBySdg.tsx
@@ -13,7 +13,7 @@ type FilterNgosBySdgProps = {
 export function FilterNgosBySdg({setSdgFilter}: FilterNgosBySdgProps) {
 
     const sdgOptions: SdgOption[] = []
-    sdgOptions.push({name: "All", value: ""})
+    sdgOptions.push({name: "all", value: ""})
 
     for (let i = 1; i < 18; i++) {
         sdgOptions.push({name: `${i}`, value: `${i}`})

--- a/frontend/src/components/NgoCard.tsx
+++ b/frontend/src/components/NgoCard.tsx
@@ -4,6 +4,7 @@ import Card from "react-bootstrap/Card";
 import {Button} from "react-bootstrap";
 import location from "./components-css/location.png";
 import {useNavigate} from "react-router-dom";
+import {PaypalDonateButton} from "./PaypalDonateButton";
 
 type ngoCardProps = {
     ngo: Ngo
@@ -32,6 +33,7 @@ export default function NgoCard({ngo}: ngoCardProps) {
                     <img src={`/sdg-images/${ngo.sdg}.png`} alt=""/>
                 </div>
                 <Card.Body>
+                    <PaypalDonateButton recipient={ngo.email}/>
                     <Button variant="light" size="sm" onClick={() => navigate(`/ngo/${ngo.id}`)}>Learn more ...</Button>
                 </Card.Body>
             </Card>

--- a/frontend/src/components/NgoOverview.tsx
+++ b/frontend/src/components/NgoOverview.tsx
@@ -43,10 +43,10 @@ export default function NgoOverview({ngos}: NgoOverviewProps) {
                                    searchName={searchName}
                                    setSearchName={setSearchName}
                                    setSdgFilter={setSdgFilter}/>
-                            <NgoBoard ngos={ngos}
-                                      regionName={"africa"}
-                                      sdgFilter={sdgFilter}
-                                      searchName={searchName}/>
+                        <NgoBoard ngos={ngos}
+                                  regionName={"africa"}
+                                  sdgFilter={sdgFilter}
+                                  searchName={searchName}/>
                     </Tab>
                     <Tab eventKey="americas"
                          title="Americas">

--- a/frontend/src/components/PaypalDonateButton.tsx
+++ b/frontend/src/components/PaypalDonateButton.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import {PayPalButtons} from "@paypal/react-paypal-js";
+
+type PaypalDonateButtonProps = {
+    recipient: string;
+}
+
+export function PaypalDonateButton({recipient}: PaypalDonateButtonProps) {
+    return (
+        <div>
+            <PayPalButtons
+            style={{ layout: 'horizontal',
+                color:  'silver',
+                shape:  'pill',
+                label:  'donate',
+                tagline: false,
+                height: 40}}
+            disabled={false}
+            createOrder={(data, actions) => {
+                return actions.order
+                    .create({
+                        purchase_units: [
+                            {
+                                amount: {
+                                    value: "2",
+                                    breakdown: {
+                                        item_total: {
+                                            currency_code: "USD",
+                                            value: "2",
+                                        },
+                                    },
+                                },
+                                payee: {
+                                    email_address: `${recipient}`
+                                },
+                                items: [
+                                    {
+                                        name: "donation",
+                                        quantity: "1",
+                                        unit_amount: {
+                                            currency_code: "USD",
+                                            value: "2",
+                                        },
+                                        category: "DONATION",
+                                    }
+                                ],
+                            },
+                        ],
+                    })
+            }}/>
+        </div>
+    )
+}


### PR DESCRIPTION
After endless unnecessary tinkering with the stupid PayPal Donate SDK which apparently does not integrate with React (yet), I now adapted the regular Checkout with PayPal function to administer donations to the different NGOs listed in the Charist database, using the e-mail address provided in the NGO signup form (or edit function for that matter). The feature is fully functional, but not super secure currently. More functionalities + security will be manufactured in after I implemented User Login + Security.

Additionally, I also connected the REST countries API in the backend, but didn't add more functionalities yet. This API will later be used to handle countries and regions.